### PR TITLE
Add JUnit tests and helper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,14 @@
             <artifactId>pcap4j-packetfactory-static</artifactId>
             <version>1.8.2</version>
         </dependency>
+
+        <!-- Testing framework -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
         
         <!-- SLF4J is provided by Spring Boot -->
     </dependencies>

--- a/src/main/java/com/monitor/metrics/CpuMetrics.java
+++ b/src/main/java/com/monitor/metrics/CpuMetrics.java
@@ -17,28 +17,34 @@ public class CpuMetrics {
         if (SystemMetrics.hardware == null) {
             throw new IllegalStateException("System hardware not initialized");
         }
-        
+
         processor = SystemMetrics.hardware.getProcessor();
         prevTicks = currTicks != null ? currTicks : processor.getSystemCpuLoadTicks();
         // Sleep a bit to get a difference
         try { Thread.sleep(100); } catch (InterruptedException ignored) {}
         currTicks = processor.getSystemCpuLoadTicks();
-        
-        long user = currTicks[TickType.USER.getIndex()] - prevTicks[TickType.USER.getIndex()];
-        long nice = currTicks[TickType.NICE.getIndex()] - prevTicks[TickType.NICE.getIndex()];
-        long sys = currTicks[TickType.SYSTEM.getIndex()] - prevTicks[TickType.SYSTEM.getIndex()];
-        long idle = currTicks[TickType.IDLE.getIndex()] - prevTicks[TickType.IDLE.getIndex()];
-        long iowait = currTicks[TickType.IOWAIT.getIndex()] - prevTicks[TickType.IOWAIT.getIndex()];
-        long irq = currTicks[TickType.IRQ.getIndex()] - prevTicks[TickType.IRQ.getIndex()];
-        long softirq = currTicks[TickType.SOFTIRQ.getIndex()] - prevTicks[TickType.SOFTIRQ.getIndex()];
-        long steal = currTicks[TickType.STEAL.getIndex()] - prevTicks[TickType.STEAL.getIndex()];
-        
-        long totalCpu = user + nice + sys + idle + iowait + irq + softirq + steal;
-        
-        cpuUsage = totalCpu > 0 ? 100d * (totalCpu - idle) / totalCpu : 0d;
-        
+
+        cpuUsage = calculateCpuUsage(prevTicks, currTicks);
+
         // Update the static last CPU load for use by other components
         lastCpuLoad = cpuUsage;
+    }
+
+    /**
+     * Calculate CPU usage percent from previous and current tick arrays.
+     */
+    static double calculateCpuUsage(long[] previous, long[] current) {
+        long user = current[TickType.USER.getIndex()] - previous[TickType.USER.getIndex()];
+        long nice = current[TickType.NICE.getIndex()] - previous[TickType.NICE.getIndex()];
+        long sys = current[TickType.SYSTEM.getIndex()] - previous[TickType.SYSTEM.getIndex()];
+        long idle = current[TickType.IDLE.getIndex()] - previous[TickType.IDLE.getIndex()];
+        long iowait = current[TickType.IOWAIT.getIndex()] - previous[TickType.IOWAIT.getIndex()];
+        long irq = current[TickType.IRQ.getIndex()] - previous[TickType.IRQ.getIndex()];
+        long softirq = current[TickType.SOFTIRQ.getIndex()] - previous[TickType.SOFTIRQ.getIndex()];
+        long steal = current[TickType.STEAL.getIndex()] - previous[TickType.STEAL.getIndex()];
+
+        long totalCpu = user + nice + sys + idle + iowait + irq + softirq + steal;
+        return totalCpu > 0 ? 100d * (totalCpu - idle) / totalCpu : 0d;
     }
     
     public void displayMetrics() {

--- a/src/test/java/com/monitor/metrics/CpuMetricsTest.java
+++ b/src/test/java/com/monitor/metrics/CpuMetricsTest.java
@@ -1,0 +1,16 @@
+package com.monitor.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CpuMetricsTest {
+
+    @Test
+    void testCalculateCpuUsage() {
+        long[] prev = new long[] {100, 0, 100, 400, 0, 0, 0, 0};
+        long[] curr = new long[] {150, 0, 150, 450, 0, 0, 0, 0};
+        double usage = CpuMetrics.calculateCpuUsage(prev, curr);
+        assertEquals(66.67, Math.round(usage * 100.0) / 100.0);
+    }
+}

--- a/src/test/java/com/monitor/util/FormatUtilTest.java
+++ b/src/test/java/com/monitor/util/FormatUtilTest.java
@@ -1,0 +1,31 @@
+package com.monitor.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FormatUtilTest {
+
+    @Test
+    void testFormatBytes() {
+        assertEquals("512 B", FormatUtil.formatBytes(512));
+        assertEquals("1.00 KB", FormatUtil.formatBytes(1024));
+    }
+
+    @Test
+    void testFormatPercent() {
+        assertEquals("12.35%", FormatUtil.formatPercent(12.345));
+    }
+
+    @Test
+    void testFormatBitRate() {
+        assertEquals("500 bps", FormatUtil.formatBitRate(500));
+        assertEquals("1.50 kbps", FormatUtil.formatBitRate(1500));
+    }
+
+    @Test
+    void testFormatTemperature() {
+        assertEquals("N/A", FormatUtil.formatTemperature(0));
+        assertEquals("36.60°C", FormatUtil.formatTemperature(36.6));
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit dependency
- expose a reusable `calculateCpuUsage` in `CpuMetrics`
- add unit tests for `FormatUtil` and `CpuMetrics`

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685395e5eac08320a4b235c2dd40bd64