### PR TITLE
Fix DecimalFormat thread safety

### DIFF
--- a/src/main/java/com/monitor/util/FormatUtil.java
+++ b/src/main/java/com/monitor/util/FormatUtil.java
@@ -2,9 +2,19 @@ package com.monitor.util;
 
 import java.text.DecimalFormat;
 
+/**
+ * Utility class for formatting numbers. The previous implementation used a
+ * single static {@link DecimalFormat} instance which is not thread safe. This
+ * caused garbled output when multiple threads accessed the formatting methods
+ * concurrently (for example the scheduled collector and web requests). To
+ * avoid this issue we use a ThreadLocal to provide each thread with its own
+ * instance of DecimalFormat.
+ */
+
 public class FormatUtil {
     
-    private static final DecimalFormat df = new DecimalFormat("0.00");
+    private static final ThreadLocal<DecimalFormat> DF =
+            ThreadLocal.withInitial(() -> new DecimalFormat("0.00"));
     
     /**
      * Format bytes into a human-readable string with appropriate units (KB, MB, GB, etc.)
@@ -15,14 +25,14 @@ public class FormatUtil {
         
         int exp = (int) (Math.log(bytes) / Math.log(unit));
         String pre = "KMGTPE".charAt(exp-1) + "";
-        return df.format(bytes / Math.pow(unit, exp)) + " " + pre + "B";
+        return DF.get().format(bytes / Math.pow(unit, exp)) + " " + pre + "B";
     }
     
     /**
      * Format a double as a percentage with two decimal places
      */
     public static String formatPercent(double value) {
-        return df.format(value) + "%";
+        return DF.get().format(value) + "%";
     }
     
     /**
@@ -34,7 +44,7 @@ public class FormatUtil {
         
         int exp = (int) (Math.log(bitsPerSecond) / Math.log(unit));
         String pre = "kMGTPE".charAt(exp-1) + "";
-        return df.format(bitsPerSecond / Math.pow(unit, exp)) + " " + pre + "bps";
+        return DF.get().format(bitsPerSecond / Math.pow(unit, exp)) + " " + pre + "bps";
     }
     
     /**
@@ -42,6 +52,7 @@ public class FormatUtil {
      */
     public static String formatTemperature(double celsius) {
         if (celsius <= 0) return "N/A";
-        return df.format(celsius) + "°C";
+        return DF.get().format(celsius) + "°C";
     }
 }
+


### PR DESCRIPTION
## Summary
- fix thread-safety issue in `FormatUtil`

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685372c2f80c832084c4f8417e210a85